### PR TITLE
[autoupdate] Add tag `v3.30.0` for `calico`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -953,6 +953,9 @@ Images:
 - SourceImage: quay.io/calico/kube-controllers
   Tags:
   - v3.30.0
+- SourceImage: quay.io/calico/node
+  Tags:
+  - v3.30.0
 - SourceImage: rancher/cluster-proportional-autoscaler
   Tags:
   - 1.7.1

--- a/config.yaml
+++ b/config.yaml
@@ -944,6 +944,9 @@ Images:
 - SourceImage: quay.io/calico/cni
   Tags:
   - v3.30.0
+- SourceImage: quay.io/calico/csi
+  Tags:
+  - v3.30.0
 - SourceImage: rancher/cluster-proportional-autoscaler
   Tags:
   - 1.7.1

--- a/config.yaml
+++ b/config.yaml
@@ -956,6 +956,9 @@ Images:
 - SourceImage: quay.io/calico/node
   Tags:
   - v3.30.0
+- SourceImage: quay.io/calico/node-driver-registrar
+  Tags:
+  - v3.30.0
 - SourceImage: rancher/cluster-proportional-autoscaler
   Tags:
   - 1.7.1

--- a/config.yaml
+++ b/config.yaml
@@ -962,6 +962,9 @@ Images:
 - SourceImage: quay.io/calico/pod2daemon-flexvol
   Tags:
   - v3.30.0
+- SourceImage: quay.io/calico/typha
+  Tags:
+  - v3.30.0
 - SourceImage: rancher/cluster-proportional-autoscaler
   Tags:
   - 1.7.1

--- a/config.yaml
+++ b/config.yaml
@@ -938,6 +938,9 @@ Images:
 - SourceImage: pstauffer/curl
   Tags:
   - v1.0.3
+- SourceImage: quay.io/calico/apiserver
+  Tags:
+  - v3.30.0
 - SourceImage: rancher/cluster-proportional-autoscaler
   Tags:
   - 1.7.1

--- a/config.yaml
+++ b/config.yaml
@@ -950,6 +950,9 @@ Images:
 - SourceImage: quay.io/calico/ctl
   Tags:
   - v3.30.0
+- SourceImage: quay.io/calico/kube-controllers
+  Tags:
+  - v3.30.0
 - SourceImage: rancher/cluster-proportional-autoscaler
   Tags:
   - 1.7.1

--- a/config.yaml
+++ b/config.yaml
@@ -941,6 +941,9 @@ Images:
 - SourceImage: quay.io/calico/apiserver
   Tags:
   - v3.30.0
+- SourceImage: quay.io/calico/cni
+  Tags:
+  - v3.30.0
 - SourceImage: rancher/cluster-proportional-autoscaler
   Tags:
   - 1.7.1

--- a/config.yaml
+++ b/config.yaml
@@ -959,6 +959,9 @@ Images:
 - SourceImage: quay.io/calico/node-driver-registrar
   Tags:
   - v3.30.0
+- SourceImage: quay.io/calico/pod2daemon-flexvol
+  Tags:
+  - v3.30.0
 - SourceImage: rancher/cluster-proportional-autoscaler
   Tags:
   - 1.7.1

--- a/config.yaml
+++ b/config.yaml
@@ -947,6 +947,9 @@ Images:
 - SourceImage: quay.io/calico/csi
   Tags:
   - v3.30.0
+- SourceImage: quay.io/calico/ctl
+  Tags:
+  - v3.30.0
 - SourceImage: rancher/cluster-proportional-autoscaler
   Tags:
   - 1.7.1

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -3725,6 +3725,12 @@ sync:
 - source: quay.io/calico/cni:v3.30.0
   target: registry.suse.com/rancher/mirrored-calico-cni:v3.30.0
   type: image
+- source: quay.io/calico/csi:v3.30.0
+  target: docker.io/rancher/mirrored-calico-csi:v3.30.0
+  type: image
+- source: quay.io/calico/csi:v3.30.0
+  target: registry.suse.com/rancher/mirrored-calico-csi:v3.30.0
+  type: image
 - source: rancher/cluster-proportional-autoscaler:1.7.1
   target: docker.io/rancher/mirrored-cluster-proportional-autoscaler:1.7.1
   type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -3761,6 +3761,12 @@ sync:
 - source: quay.io/calico/pod2daemon-flexvol:v3.30.0
   target: registry.suse.com/rancher/mirrored-calico-pod2daemon-flexvol:v3.30.0
   type: image
+- source: quay.io/calico/typha:v3.30.0
+  target: docker.io/rancher/mirrored-calico-typha:v3.30.0
+  type: image
+- source: quay.io/calico/typha:v3.30.0
+  target: registry.suse.com/rancher/mirrored-calico-typha:v3.30.0
+  type: image
 - source: rancher/cluster-proportional-autoscaler:1.7.1
   target: docker.io/rancher/mirrored-cluster-proportional-autoscaler:1.7.1
   type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -3743,6 +3743,12 @@ sync:
 - source: quay.io/calico/kube-controllers:v3.30.0
   target: registry.suse.com/rancher/mirrored-calico-kube-controllers:v3.30.0
   type: image
+- source: quay.io/calico/node:v3.30.0
+  target: docker.io/rancher/mirrored-calico-node:v3.30.0
+  type: image
+- source: quay.io/calico/node:v3.30.0
+  target: registry.suse.com/rancher/mirrored-calico-node:v3.30.0
+  type: image
 - source: rancher/cluster-proportional-autoscaler:1.7.1
   target: docker.io/rancher/mirrored-cluster-proportional-autoscaler:1.7.1
   type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -3731,6 +3731,12 @@ sync:
 - source: quay.io/calico/csi:v3.30.0
   target: registry.suse.com/rancher/mirrored-calico-csi:v3.30.0
   type: image
+- source: quay.io/calico/ctl:v3.30.0
+  target: docker.io/rancher/mirrored-calico-ctl:v3.30.0
+  type: image
+- source: quay.io/calico/ctl:v3.30.0
+  target: registry.suse.com/rancher/mirrored-calico-ctl:v3.30.0
+  type: image
 - source: rancher/cluster-proportional-autoscaler:1.7.1
   target: docker.io/rancher/mirrored-cluster-proportional-autoscaler:1.7.1
   type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -3737,6 +3737,12 @@ sync:
 - source: quay.io/calico/ctl:v3.30.0
   target: registry.suse.com/rancher/mirrored-calico-ctl:v3.30.0
   type: image
+- source: quay.io/calico/kube-controllers:v3.30.0
+  target: docker.io/rancher/mirrored-calico-kube-controllers:v3.30.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.30.0
+  target: registry.suse.com/rancher/mirrored-calico-kube-controllers:v3.30.0
+  type: image
 - source: rancher/cluster-proportional-autoscaler:1.7.1
   target: docker.io/rancher/mirrored-cluster-proportional-autoscaler:1.7.1
   type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -3755,6 +3755,12 @@ sync:
 - source: quay.io/calico/node-driver-registrar:v3.30.0
   target: registry.suse.com/rancher/mirrored-calico-node-driver-registrar:v3.30.0
   type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.30.0
+  target: docker.io/rancher/mirrored-calico-pod2daemon-flexvol:v3.30.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.30.0
+  target: registry.suse.com/rancher/mirrored-calico-pod2daemon-flexvol:v3.30.0
+  type: image
 - source: rancher/cluster-proportional-autoscaler:1.7.1
   target: docker.io/rancher/mirrored-cluster-proportional-autoscaler:1.7.1
   type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -3749,6 +3749,12 @@ sync:
 - source: quay.io/calico/node:v3.30.0
   target: registry.suse.com/rancher/mirrored-calico-node:v3.30.0
   type: image
+- source: quay.io/calico/node-driver-registrar:v3.30.0
+  target: docker.io/rancher/mirrored-calico-node-driver-registrar:v3.30.0
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.30.0
+  target: registry.suse.com/rancher/mirrored-calico-node-driver-registrar:v3.30.0
+  type: image
 - source: rancher/cluster-proportional-autoscaler:1.7.1
   target: docker.io/rancher/mirrored-cluster-proportional-autoscaler:1.7.1
   type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -3719,6 +3719,12 @@ sync:
 - source: quay.io/calico/apiserver:v3.30.0
   target: registry.suse.com/rancher/mirrored-calico-apiserver:v3.30.0
   type: image
+- source: quay.io/calico/cni:v3.30.0
+  target: docker.io/rancher/mirrored-calico-cni:v3.30.0
+  type: image
+- source: quay.io/calico/cni:v3.30.0
+  target: registry.suse.com/rancher/mirrored-calico-cni:v3.30.0
+  type: image
 - source: rancher/cluster-proportional-autoscaler:1.7.1
   target: docker.io/rancher/mirrored-cluster-proportional-autoscaler:1.7.1
   type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -3713,6 +3713,12 @@ sync:
 - source: pstauffer/curl:v1.0.3
   target: registry.suse.com/rancher/mirrored-pstauffer-curl:v1.0.3
   type: image
+- source: quay.io/calico/apiserver:v3.30.0
+  target: docker.io/rancher/mirrored-calico-apiserver:v3.30.0
+  type: image
+- source: quay.io/calico/apiserver:v3.30.0
+  target: registry.suse.com/rancher/mirrored-calico-apiserver:v3.30.0
+  type: image
 - source: rancher/cluster-proportional-autoscaler:1.7.1
   target: docker.io/rancher/mirrored-cluster-proportional-autoscaler:1.7.1
   type: image


### PR DESCRIPTION
This PR was created by the autoupdate workflow.

It adds the tag `v3.30.0` for the following images:
- `quay.io/calico/apiserver`
- `quay.io/calico/cni`
- `quay.io/calico/csi`
- `quay.io/calico/ctl`
- `quay.io/calico/kube-controllers`
- `quay.io/calico/node`
- `quay.io/calico/node-driver-registrar`
- `quay.io/calico/pod2daemon-flexvol`
- `quay.io/calico/typha`