### PR TITLE
[autoupdate] Add tag `v4.8.1` for `csi-attacher`

### DIFF
--- a/autoupdate.yaml
+++ b/autoupdate.yaml
@@ -1,0 +1,93 @@
+- GithubLatestRelease:
+    Images:
+    - quay.io/calico/apiserver
+    - quay.io/calico/cni
+    - quay.io/calico/csi
+    - quay.io/calico/ctl
+    - quay.io/calico/kube-controllers
+    - quay.io/calico/node
+    - quay.io/calico/node-driver-registrar
+    - quay.io/calico/pod2daemon-flexvol
+    - quay.io/calico/typha
+    Owner: projectcalico
+    Repository: calico
+  Name: calico
+- GithubLatestRelease:
+    Images:
+    - registry.k8s.io/sig-storage/csi-attacher
+    Owner: kubernetes-csi
+    Repository: external-attacher
+  Name: csi-attacher
+- GithubLatestRelease:
+    Images:
+    - registry.k8s.io/sig-storage/csi-node-driver-registrar
+    Owner: kubernetes-csi
+    Repository: node-driver-registrar
+  Name: csi-driver-registrar
+- GithubLatestRelease:
+    Images:
+    - registry.k8s.io/sig-storage/csi-provisioner
+    Owner: kubernetes-csi
+    Repository: external-provisioner
+  Name: csi-provisioner
+- GithubLatestRelease:
+    Images:
+    - registry.k8s.io/sig-storage/csi-resizer
+    Owner: kubernetes-csi
+    Repository: external-resizer
+  Name: csi-resizer
+- GithubLatestRelease:
+    Images:
+    - registry.k8s.io/sig-storage/csi-snapshotter
+    Owner: kubernetes-csi
+    Repository: external-snapshotter
+  Name: csi-snapshotter
+- GithubLatestRelease:
+    Images:
+    - flannel/flannel
+    Owner: flannel-io
+    Repository: flannel
+  Name: flannel
+- GithubLatestRelease:
+    Images:
+    - flannel/flannel-cni-plugin
+    Owner: flannel-io
+    Repository: cni-plugin
+  Name: flannel-cni-plugin
+- GithubLatestRelease:
+    Images:
+    - ghcr.io/kube-vip/kube-vip-iptables
+    Owner: kube-vip
+    Repository: kube-vip
+  Name: kube-vip-iptables
+- GithubLatestRelease:
+    Images:
+    - idealista/prom2teams
+    Owner: idealista
+    Repository: prom2teams
+  Name: prom2teams
+- GithubLatestRelease:
+    Images:
+    - registry.k8s.io/sig-storage/snapshot-controller
+    Owner: kubernetes-csi
+    Repository: external-snapshotter
+  Name: snapshot-controller
+- GithubLatestRelease:
+    Images:
+    - sonobuoy/sonobuoy
+    Owner: vmware-tanzu
+    Repository: sonobuoy
+  Name: sonobuoy
+- GithubLatestRelease:
+    Images:
+    - registry.k8s.io/sig-storage/livenessprobe
+    Owner: kubernetes-csi
+    Repository: livenessprobe
+  Name: storage-livenessprobe
+- GithubLatestRelease:
+    Images:
+    - registry.k8s.io/csi-vsphere/driver
+    - registry.k8s.io/csi-vsphere/syncer
+    Owner: kubernetes-sigs
+    Repository: vsphere-csi-driver
+  Name: vsphere-csi

--- a/config.yaml
+++ b/config.yaml
@@ -1095,6 +1095,9 @@ Images:
   - v0.11.2
   - v0.12.0
   - v0.9.0
+- SourceImage: registry.k8s.io/sig-storage/csi-attacher
+  Tags:
+  - v4.8.1
 - SourceImage: registry.k8s.io/sig-storage/snapshot-validation-webhook
   Tags:
   - v6.1.0

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4337,6 +4337,12 @@ sync:
 - source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.9.0
   target: registry.suse.com/rancher/mirrored-prometheus-adapter-prometheus-adapter:v0.9.0
   type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.8.1
+  target: docker.io/rancher/mirrored-sig-storage-csi-attacher:v4.8.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.8.1
+  target: registry.suse.com/rancher/mirrored-sig-storage-csi-attacher:v4.8.1
+  type: image
 - source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.1.0
   target: docker.io/rancher/mirrored-sig-storage-snapshot-validation-webhook:v6.1.0
   type: image


### PR DESCRIPTION
This PR was created by the autoupdate workflow.

It adds the tag `v4.8.1` for the following images:
- `registry.k8s.io/sig-storage/csi-attacher`