### PR TITLE
[autoupdate] Add tag `v2.13.0` for `csi-driver-registrar`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1095,6 +1095,9 @@ Images:
   - v0.11.2
   - v0.12.0
   - v0.9.0
+- SourceImage: registry.k8s.io/sig-storage/csi-node-driver-registrar
+  Tags:
+  - v2.13.0
 - SourceImage: registry.k8s.io/sig-storage/snapshot-validation-webhook
   Tags:
   - v6.1.0

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4337,6 +4337,12 @@ sync:
 - source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.9.0
   target: registry.suse.com/rancher/mirrored-prometheus-adapter-prometheus-adapter:v0.9.0
   type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+  target: docker.io/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+  target: registry.suse.com/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0
+  type: image
 - source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.1.0
   target: docker.io/rancher/mirrored-sig-storage-snapshot-validation-webhook:v6.1.0
   type: image


### PR DESCRIPTION
This PR was created by the autoupdate workflow.

It adds the tag `v2.13.0` for the following images:
- `registry.k8s.io/sig-storage/csi-node-driver-registrar`