### PR TITLE
[autoupdate] Add 1 tag(s) for `csi-resizer`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1095,6 +1095,9 @@ Images:
   - v0.11.2
   - v0.12.0
   - v0.9.0
+- SourceImage: registry.k8s.io/sig-storage/csi-resizer
+  Tags:
+  - v1.13.2
 - SourceImage: registry.k8s.io/sig-storage/snapshot-validation-webhook
   Tags:
   - v6.1.0
@@ -1113,11 +1116,6 @@ Images:
   - 15.6.19.1
   - 15.6.24.2
   TargetImageName: mirrored-bci-micro
-- DoNotMirror: true
-  SourceImage: registry.suse.com/rancher/elemental-operator
-  Tags:
-  - 1.3.4
-  TargetImageName: mirrored-elemental-operator
 - SourceImage: registry.suse.com/rancher/elemental-operator
   Tags:
   - 1.4.2
@@ -1128,6 +1126,11 @@ Images:
   - 1.6.5
   - 1.6.8
   - 1.6.9
+  TargetImageName: mirrored-elemental-operator
+- DoNotMirror: true
+  SourceImage: registry.suse.com/rancher/elemental-operator
+  Tags:
+  - 1.3.4
   TargetImageName: mirrored-elemental-operator
 - SourceImage: registry.suse.com/rancher/seedimage-builder
   Tags:

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4337,6 +4337,12 @@ sync:
 - source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.9.0
   target: registry.suse.com/rancher/mirrored-prometheus-adapter-prometheus-adapter:v0.9.0
   type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.13.2
+  target: docker.io/rancher/mirrored-sig-storage-csi-resizer:v1.13.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.13.2
+  target: registry.suse.com/rancher/mirrored-sig-storage-csi-resizer:v1.13.2
+  type: image
 - source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.1.0
   target: docker.io/rancher/mirrored-sig-storage-snapshot-validation-webhook:v6.1.0
   type: image


### PR DESCRIPTION
This PR was created by the autoupdate workflow.

It adds the following image tags:
- `registry.k8s.io/sig-storage/csi-resizer:v1.13.2`