### PR TITLE
[autoupdate] Add 1 tag(s) for `flannel-cni-plugin`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -90,6 +90,9 @@ Images:
   Tags:
   - v0.7.0
   - v0.8.3
+- SourceImage: flannel/flannel-cni-plugin
+  Tags:
+  - v1.7.1-flannel1
 - SourceImage: flannelcni/flannel
   Tags:
   - v0.16.0

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -365,6 +365,12 @@ sync:
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.8.3
   target: registry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.8.3
   type: image
+- source: flannel/flannel-cni-plugin:v1.7.1-flannel1
+  target: docker.io/rancher/mirrored-flannel-flannel-cni-plugin:v1.7.1-flannel1
+  type: image
+- source: flannel/flannel-cni-plugin:v1.7.1-flannel1
+  target: registry.suse.com/rancher/mirrored-flannel-flannel-cni-plugin:v1.7.1-flannel1
+  type: image
 - source: flannelcni/flannel:v0.16.0
   target: docker.io/rancher/mirrored-flannelcni-flannel:v0.16.0
   type: image


### PR DESCRIPTION
This PR was created by the autoupdate workflow.

It adds the following image tags:
- `flannel/flannel-cni-plugin:v1.7.1-flannel1`