### PR TITLE
[autoupdate] Add 1 tag(s) for `kube-vip-iptables`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -370,6 +370,9 @@ Images:
   - 4.4.0
   - 4.8.0
   - 4.9.1
+- SourceImage: ghcr.io/kube-vip/kube-vip-iptables
+  Tags:
+  - v0.9.1
 - SourceImage: ghcr.io/prometheus-community/windows-exporter
   Tags:
   - 0.25.1
@@ -1113,11 +1116,6 @@ Images:
   - 15.6.19.1
   - 15.6.24.2
   TargetImageName: mirrored-bci-micro
-- DoNotMirror: true
-  SourceImage: registry.suse.com/rancher/elemental-operator
-  Tags:
-  - 1.3.4
-  TargetImageName: mirrored-elemental-operator
 - SourceImage: registry.suse.com/rancher/elemental-operator
   Tags:
   - 1.4.2
@@ -1128,6 +1126,11 @@ Images:
   - 1.6.5
   - 1.6.8
   - 1.6.9
+  TargetImageName: mirrored-elemental-operator
+- DoNotMirror: true
+  SourceImage: registry.suse.com/rancher/elemental-operator
+  Tags:
+  - 1.3.4
   TargetImageName: mirrored-elemental-operator
 - SourceImage: registry.suse.com/rancher/seedimage-builder
   Tags:

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -1103,6 +1103,12 @@ sync:
 - source: ghcr.io/kube-logging/logging-operator:4.9.1
   target: registry.suse.com/rancher/mirrored-kube-logging-logging-operator:4.9.1
   type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.1
+  target: docker.io/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.1
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.1
+  target: registry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.1
+  type: image
 - source: ghcr.io/prometheus-community/windows-exporter:0.25.1
   target: docker.io/rancher/mirrored-prometheus-windows-exporter:0.25.1
   type: image


### PR DESCRIPTION
This PR was created by the autoupdate workflow.

It adds the following image tags:
- `ghcr.io/kube-vip/kube-vip-iptables:v0.9.1`