### PR TITLE
[autoupdate] Add 1 tag(s) for `prom2teams`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -411,6 +411,9 @@ Images:
   - 3.11.6
   - 3.12.3
   - 3.8.0
+- SourceImage: idealista/prom2teams
+  Tags:
+  - 5.0.0
 - SourceImage: istio/citadel
   Tags:
   - 1.5.9

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -1271,6 +1271,12 @@ sync:
 - source: grafana/grafana-image-renderer:3.8.0
   target: registry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:3.8.0
   type: image
+- source: idealista/prom2teams:5.0.0
+  target: docker.io/rancher/mirrored-idealista-prom2teams:5.0.0
+  type: image
+- source: idealista/prom2teams:5.0.0
+  target: registry.suse.com/rancher/mirrored-idealista-prom2teams:5.0.0
+  type: image
 - source: istio/citadel:1.5.9
   target: docker.io/rancher/mirrored-istio-citadel:1.5.9
   type: image


### PR DESCRIPTION
This PR was created by the autoupdate workflow.

It adds the following image tags:
- `idealista/prom2teams:5.0.0`