### PR TITLE
[autoupdate] Add 2 tag(s) for `vsphere-csi`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -988,6 +988,9 @@ Images:
 - SourceImage: registry.k8s.io/csi-vsphere/driver
   Tags:
   - v3.4.0
+- SourceImage: registry.k8s.io/csi-vsphere/syncer
+  Tags:
+  - v3.4.0
 - SourceImage: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny
   Tags:
   - 1.17.3

--- a/config.yaml
+++ b/config.yaml
@@ -985,6 +985,9 @@ Images:
   - v1.8.9
   - v1.9.0
   TargetImageName: mirrored-cluster-proportional-autoscaler
+- SourceImage: registry.k8s.io/csi-vsphere/driver
+  Tags:
+  - v3.4.0
 - SourceImage: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny
   Tags:
   - 1.17.3
@@ -1113,11 +1116,6 @@ Images:
   - 15.6.19.1
   - 15.6.24.2
   TargetImageName: mirrored-bci-micro
-- DoNotMirror: true
-  SourceImage: registry.suse.com/rancher/elemental-operator
-  Tags:
-  - 1.3.4
-  TargetImageName: mirrored-elemental-operator
 - SourceImage: registry.suse.com/rancher/elemental-operator
   Tags:
   - 1.4.2
@@ -1128,6 +1126,11 @@ Images:
   - 1.6.5
   - 1.6.8
   - 1.6.9
+  TargetImageName: mirrored-elemental-operator
+- DoNotMirror: true
+  SourceImage: registry.suse.com/rancher/elemental-operator
+  Tags:
+  - 1.3.4
   TargetImageName: mirrored-elemental-operator
 - SourceImage: registry.suse.com/rancher/seedimage-builder
   Tags:

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -3875,6 +3875,12 @@ sync:
 - source: registry.k8s.io/csi-vsphere/driver:v3.4.0
   target: registry.suse.com/rancher/mirrored-csi-vsphere-driver:v3.4.0
   type: image
+- source: registry.k8s.io/csi-vsphere/syncer:v3.4.0
+  target: docker.io/rancher/mirrored-csi-vsphere-syncer:v3.4.0
+  type: image
+- source: registry.k8s.io/csi-vsphere/syncer:v3.4.0
+  target: registry.suse.com/rancher/mirrored-csi-vsphere-syncer:v3.4.0
+  type: image
 - source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.3
   target: docker.io/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.17.3
   type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -3869,6 +3869,12 @@ sync:
 - source: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
   target: registry.suse.com/rancher/mirrored-cluster-proportional-autoscaler:v1.9.0
   type: image
+- source: registry.k8s.io/csi-vsphere/driver:v3.4.0
+  target: docker.io/rancher/mirrored-csi-vsphere-driver:v3.4.0
+  type: image
+- source: registry.k8s.io/csi-vsphere/driver:v3.4.0
+  target: registry.suse.com/rancher/mirrored-csi-vsphere-driver:v3.4.0
+  type: image
 - source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.3
   target: docker.io/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.17.3
   type: image


### PR DESCRIPTION
This PR was created by the autoupdate workflow.

It adds the following image tags:
- `registry.k8s.io/csi-vsphere/driver:v3.4.0`
- `registry.k8s.io/csi-vsphere/syncer:v3.4.0`